### PR TITLE
Expose kintone-plugin-packer/from-manifest

### DIFF
--- a/from-manifest.js
+++ b/from-manifest.js
@@ -1,0 +1,3 @@
+'use strict';
+
+module.exports = require('./src/pack-plugin-from-manifest');

--- a/src/create-contents-zip.js
+++ b/src/create-contents-zip.js
@@ -1,0 +1,37 @@
+'use strict';
+
+const path = require('path');
+const ZipFile = require('yazl').ZipFile;
+
+const streamBuffers = require('stream-buffers');
+const debug = require('debug')('create-contents-zip');
+
+const sourceList = require('./sourcelist');
+
+/**
+ * Create a zipped contents
+ *
+ * @param {string} pluginDir
+ * @param {!Object} manifest
+ * @return {!Promise<!Buffer>}
+ */
+function createContentsZip(pluginDir, manifest) {
+  return new Promise((res, rej) => {
+    const output = new streamBuffers.WritableStreamBuffer();
+    const zipFile = new ZipFile();
+    let size = null;
+    output.on('finish', () => {
+      debug(`plugin.zip: ${size} bytes`);
+      res(output.getContents());
+    });
+    zipFile.outputStream.pipe(output);
+    sourceList(manifest).forEach(src => {
+      zipFile.addFile(path.join(pluginDir, src), src);
+    });
+    zipFile.end(finalSize => {
+      size = finalSize;
+    });
+  });
+}
+
+module.exports = createContentsZip;

--- a/src/pack-plugin-from-manifest.js
+++ b/src/pack-plugin-from-manifest.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const packer = require('./index');
+const createContentsZip = require('./create-contents-zip');
+
+/**
+ * @param {!string} manifestJSONPath The path of the manifest.json for the plugin
+ * @param {string=} privateKey The private key (PKCS#1 PEM).
+ * @return {!Promise<{plugin: !Buffer, privateKey: string, id: string}>}
+ */
+function packPluginFromManifest(manifestJSONPath, privateKey) {
+  return new Promise((resolve, reject) => {
+    try {
+      resolve(JSON.parse(fs.readFileSync(manifestJSONPath, 'utf-8')));
+    } catch (e) {
+      reject(e);
+    }
+  })
+    .then(manifest => createContentsZip(path.dirname(manifestJSONPath), manifest))
+    .then(buffer => packer(buffer, privateKey));
+}
+
+module.exports = packPluginFromManifest;

--- a/test/create-contents-zip.js
+++ b/test/create-contents-zip.js
@@ -1,0 +1,24 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const AdmZip = require('adm-zip');
+
+const createContentsZip = require('../src/create-contents-zip');
+
+const fixturesDir = path.join(__dirname, 'fixtures');
+const pluginDir = path.join(fixturesDir, 'sample-plugin', 'plugin-dir');
+
+describe('create-contents-zip', () => {
+  it('should be able to create buffer from a plugin directory', done => {
+    const manifestJSONPath = path.join(pluginDir, 'manifest.json');
+    const manifest = JSON.parse(fs.readFileSync(manifestJSONPath, 'utf-8'));
+    createContentsZip(pluginDir, manifest).then(buffer => {
+      const files = new AdmZip(buffer).getEntries().map(e => e.entryName);
+      assert.deepStrictEqual(files, ['manifest.json', 'image/icon.png']);
+      assert(buffer instanceof Buffer);
+      done();
+    });
+  });
+});

--- a/test/pack-plugin-from-manifest.js
+++ b/test/pack-plugin-from-manifest.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+const AdmZip = require('adm-zip');
+
+const packer = require('../src/');
+const packPluginFromManifest = require('../src/pack-plugin-from-manifest');
+const createContentsZip = require('../src/create-contents-zip');
+
+const fixturesDir = path.join(__dirname, 'fixtures');
+const ppkFilePath = path.join(fixturesDir, 'private.ppk');
+const pluginDir = path.join(fixturesDir, 'sample-plugin', 'plugin-dir');
+
+describe('pack-plugin-from-manifest', () => {
+  it('should be able to create a plugin from the manifest json path', done => {
+    const manifestJSONPath = path.join(pluginDir, 'manifest.json');
+    const privateKey = fs.readFileSync(ppkFilePath, 'utf-8');
+    const manifest = JSON.parse(fs.readFileSync(manifestJSONPath, 'utf-8'));
+    Promise.all([
+      packPluginFromManifest(manifestJSONPath, privateKey),
+      createContentsZip(pluginDir, manifest).then(buffer => packer(buffer, privateKey)),
+    ]).then(([result1, result2]) => {
+      assert(result1.id === result2.id);
+      assert(result1.plugin.length === result2.plugin.length);
+      assert(result1.privateKey === result2.privateKey);
+      const files = new AdmZip(result1.plugin).getEntries().map(e => e.entryName);
+      assert.deepStrictEqual(files, ['contents.zip', 'PUBKEY', 'SIGNATURE']);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
When I use the Node API of `kintone-plugin-packer`, I have to create a buffer of a zipped contents.
In order to create the buffer, I have to implement a feature that is implemented in `kintone-plugin-packer`, which is a creating the buffer based on the `manifest.json`.

I think it would be nice if `kintone-plugin-packer` had an API to create a plugin from a path of a manifest.json.
This PR is to expose the API.

```js
const packPluginFromManifest = require('kintone-plugin-packer/from-manifest');
packPluginFromManifest('path/to/manifest.json', privateKey).then(output => {
  console.log(output.id);
  fs.writeFileSync('./private.ppk', output.privateKey);
  fs.writeFileSync('./plugin.zip', output.plugin);
});
```

It's fine for me to expose `createContentsZip` but it seems to not be useful for others except me. :)