### PR TITLE
feat(cli): add --watch option to create a plugin zip automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ $ kintone-plugin-packer [OPTIONS] PLUGIN_DIR
 
 - `--ppk PPK_FILE`: The path of input private key file. If omitted, it is generated automatically into `<Plugin ID>.ppk` in the same directory of `PLUGIN_DIR` or `--out` if specified.
 - `--out PLUGIN_FILE`: The path of generated plugin file. The default is `plugin.zip` in the same directory of `PLUGIN_DIR`.
+- `--watch`: Watch PLUGIN_DIR for the changes.
 
 
 ## How to use with `npm run`

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -14,6 +14,9 @@ const flagSpec = {
   out: {
     type: 'string',
   },
+  watch: {
+    type: 'boolean',
+  },
 };
 
 const cli = meow(
@@ -24,6 +27,7 @@ Usage
 Options
   --ppk PPK_FILE: Private key file. If omitted, it's generated into '<Plugin ID>.ppk' in the same directory of PLUGIN_DIR.
   --out PLUGIN_FILE: The default is 'plugin.zip' in the same directory of PLUGIN_DIR.
+  --watch: Watch PLUGIN_DIR for the changes.
 `,
   {
     flag: flagSpec,

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "dependencies": {
     "@teppeis/kintone-plugin-manifest-validator": "^0.6.1",
+    "chokidar": "^2.0.2",
     "debug": "^3.1.0",
     "denodeify": "^1.2.1",
     "meow": "^4.0.0",

--- a/test/cli.js
+++ b/test/cli.js
@@ -35,28 +35,38 @@ describe('cli', () => {
       });
     });
 
-    it('invalid `url`', () => {
-      assert.throws(() => {
-        cli(path.join(fixturesDir, 'plugin-invalid-url'), {packerMock_: packer});
-      }, /Invalid manifest.json/);
+    it('invalid `url`', done => {
+      cli(path.join(fixturesDir, 'plugin-invalid-url'), {packerMock_: packer}).catch(error => {
+        assert(/Invalid manifest.json/.test(error.message));
+        done();
+      });
     });
 
-    it('invalid `https-url`', () => {
-      assert.throws(() => {
-        cli(path.join(fixturesDir, 'plugin-invalid-https-url'), {packerMock_: packer});
-      }, /Invalid manifest.json/);
+    it('invalid `https-url`', done => {
+      cli(path.join(fixturesDir, 'plugin-invalid-https-url'), {packerMock_: packer}).catch(
+        error => {
+          assert(/Invalid manifest.json/.test(error.message));
+          done();
+        }
+      );
     });
 
-    it('invalid `relative-path`', () => {
-      assert.throws(() => {
-        cli(path.join(fixturesDir, 'plugin-invalid-relative-path'), {packerMock_: packer});
-      }, /Invalid manifest.json/);
+    it('invalid `relative-path`', done => {
+      cli(path.join(fixturesDir, 'plugin-invalid-relative-path'), {packerMock_: packer}).catch(
+        error => {
+          assert(/Invalid manifest.json/.test(error.message));
+          done();
+        }
+      );
     });
 
-    it('invalid `maxFileSize`', () => {
-      assert.throws(() => {
-        cli(path.join(fixturesDir, 'plugin-invalid-maxFileSize'), {packerMock_: packer});
-      }, /Invalid manifest.json/);
+    it('invalid `maxFileSize`', done => {
+      cli(path.join(fixturesDir, 'plugin-invalid-maxFileSize'), {packerMock_: packer}).catch(
+        error => {
+          assert(/Invalid manifest.json/.test(error.message));
+          done();
+        }
+      );
     });
   });
 


### PR DESCRIPTION
I think it would be nice if `kintone-plugin-packer` had a `--watch` option, so I've added it.
Using this PR, developers no longer run `kintone-plugin-packer` command manually after each change.

It's very useful, isn't it?

In this PR, I've updated the interface of cli.js to return always a promise if an error occurred. Current implementation might throw errors so we have to care about a case throw errors using try-catch. I think returning an error as a rejected promise seems to be better than throw an error at the point of consistency. Even though it might be a breaking change.